### PR TITLE
Remove density from PRODUCT_AAPT_CONFIG

### DIFF
--- a/camera/QCamera2/HAL/QCameraStateMachine.cpp
+++ b/camera/QCamera2/HAL/QCameraStateMachine.cpp
@@ -1129,38 +1129,38 @@ int32_t QCameraStateMachine::procEvtPreviewingState(qcamera_sm_evt_enum_t evt,
         break;
     case QCAMERA_SM_EVT_TAKE_PICTURE:
        {
-           if ( m_parent->mParameters.getRecordingHintValue() == false) {
-               if (m_parent->isZSLMode() || m_parent->isLongshotEnabled()) {
-                   m_state = QCAMERA_SM_STATE_PREVIEW_PIC_TAKING;
-                   rc = m_parent->takePicture();
-                   if (rc != NO_ERROR) {
-                       // move state to previewing state
-                       m_state = QCAMERA_SM_STATE_PREVIEWING;
-                   }
-               } else {
-                   m_state = QCAMERA_SM_STATE_PIC_TAKING;
-                   rc = m_parent->takePicture();
-                   if (rc != NO_ERROR) {
-                       // move state to preview stopped state
-                       m_state = QCAMERA_SM_STATE_PREVIEW_STOPPED;
-                   }
-               }
-
-               result.status = rc;
-               result.request_api = evt;
-               result.result_type = QCAMERA_API_RESULT_TYPE_DEF;
-               m_parent->signalAPIResult(&result);
-           } else {
+           if ( m_parent->mParameters.getRecordingHintValue() == true) {
+                m_parent->stopPreview();
+                m_parent->mParameters.updateRecordingHintValue(FALSE);
+                // start preview again
+                rc = m_parent->preparePreview();
+                if (rc == NO_ERROR) {
+                    rc = m_parent->startPreview();
+                    if (rc != NO_ERROR) {
+                        m_parent->unpreparePreview();
+                    }
+                }
+           }
+           if (m_parent->isZSLMode() || m_parent->isLongshotEnabled()) {
                m_state = QCAMERA_SM_STATE_PREVIEW_PIC_TAKING;
-               rc = m_parent->takeLiveSnapshot();
-               if (rc != NO_ERROR ) {
+               rc = m_parent->takePicture();
+               if (rc != NO_ERROR) {
+                   // move state to previewing state
                    m_state = QCAMERA_SM_STATE_PREVIEWING;
                }
-               result.status = rc;
-               result.request_api = evt;
-               result.result_type = QCAMERA_API_RESULT_TYPE_DEF;
-               m_parent->signalAPIResult(&result);
+           } else {
+               m_state = QCAMERA_SM_STATE_PIC_TAKING;
+               rc = m_parent->takePicture();
+               if (rc != NO_ERROR) {
+                   // move state to preview stopped state
+                   m_state = QCAMERA_SM_STATE_PREVIEW_STOPPED;
+               }
            }
+
+           result.status = rc;
+           result.request_api = evt;
+           result.result_type = QCAMERA_API_RESULT_TYPE_DEF;
+           m_parent->signalAPIResult(&result);
         }
         break;
     case QCAMERA_SM_EVT_SEND_COMMAND:

--- a/device.mk
+++ b/device.mk
@@ -25,7 +25,7 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml
 
 # Screen density
-PRODUCT_AAPT_CONFIG := normal hdpi xhdpi
+PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 # Boot animation


### PR DESCRIPTION
AAPT ignores densities in PRODUCT_AAPT_CONFIG.
The use of PRODUCT_AAPT_PREF_CONFIG for density is
encouraged, as AAPT is able to determine the fallback
density to use if a resource of the specified density
does not exist.

Change-Id: If2b43a44593bc234118045d03bd48cd9820dc05a